### PR TITLE
mailContext: Fix config parser

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -40,9 +40,14 @@ if you use our friendly extended context
             alias_entity:
                 enabled: true
             mails:
-                path: "path/to/emailConfig/directory"
-                key: mailsconfigkey
-                translation:
-                    firstCharacter: "%"
-                    lastCharacter: "%"
+                default:
+                    path: "path/to/emailConfig/directory"
+                    key: mailsconfigkey
+                    translation:
+                        firstCharacter: "%"
+                        lastCharacter: "%"
+                config_2:
+                    path: "…"
+                    key: "…"
+                    […]
 ```

--- a/src/Troopers/BehatContexts/Parser/Mail/MailParser.php
+++ b/src/Troopers/BehatContexts/Parser/Mail/MailParser.php
@@ -31,10 +31,12 @@ class MailParser
 
     public function loadMails()
     {
-        $config = $this->reader->load($this->mailsConfig['path'], $this->mailsConfig['key']);
-        foreach ($config as $eventName => $emailConfig) {
-            $this->validMailConfig($eventName, $emailConfig);
-            $this->mailCollection->set($eventName, $emailConfig);
+        foreach ($this->mailsConfig as $mailConfig) {
+            $config = $this->reader->load($mailConfig['path'], $mailConfig['key']);
+            foreach ($config as $eventName => $emailConfig) {
+                $this->validMailConfig($eventName, $emailConfig);
+                $this->mailCollection->set($eventName, $emailConfig);
+            }
         }
     }
 


### PR DESCRIPTION
`->prototype('array')` is used to *define a prototype for each node inside an array node* (see [Symfony's documentation](http://symfony.com/doc/2.8/components/config/definition.html#array-nodes)), so I updated the config parser in order to read this array properly.

Fixes #21.