### PR TITLE
Define MailCatcher server variables for PHPUnit tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -12,6 +12,6 @@ dependencies:
 
 test:
   override:
-    - vendor/phpunit/phpunit/phpunit src/ --verbose --tap
+    - vendor/bin/phpunit --verbose --tap
     - vendor/bin/behat --config behat.yml
     - vendor/bin/behat --config behat_config.yml

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- https://phpunit.de/manual/3.7/en/appendixes.configuration.html -->
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/3.7/phpunit.xsd"
+        backupGlobals="false"
+        backupStaticAttributes="false"
+        bootstrap="vendor/autoload.php"
+        colors="true"
+        convertErrorsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertWarningsToExceptions="true"
+        beStrictAboutTestsThatDoNotTestAnything="true"
+        beStrictAboutOutputDuringTests="true"
+        beStrictAboutTestSize="true"
+        reportUselessTests="true"
+        disallowTestOutput="true"
+>
+
+    <php>
+        <server name="MAILCATCHER_HTTP" value="http://127.0.0.1:1080"/>
+        <server name="MAILCATCHER_SMTP" value="smtp://127.0.0.1:1025"/>
+    </php>
+
+    <testsuites>
+        <testsuite name="Project Test Suite">
+            <directory>src/Troopers/BehatContexts/Tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
So these variables won't have to be defined in CircleCI settings