### PR TITLE
allow symfony > 3.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,12 +7,12 @@
         "behat/behat": "~3.0",
         "knplabs/friendly-contexts": "0.7",
         "alexandresalome/mailcatcher": "~1.2",
-        "symfony/finder": ">=2.7 <3.2",
-        "symfony/yaml": ">=2.7 <3.2",
-        "symfony/dependency-injection": ">=2.7 <3.2",
+        "symfony/finder": ">=2.7|~3.0",
+        "symfony/yaml": ">=2.7|~3.0",
+        "symfony/dependency-injection": ">=2.7|~3.0",
         "doctrine/dbal": "^2.5",
         "doctrine/orm": "^2.5",
-        "symfony/property-access": ">=2.8"
+        "symfony/property-access": ">=2.8|~3.0"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
Sorry, I haven't read your previous PR #32 , because the title did not meet my needs.

Obviously we can keep compatibility with symfony 3.3 with the contextMail, maybe we have to treat the 2 PR, one for the upgrade of comptaibility and the other for the clean?